### PR TITLE
Correct misconfigured product photos upload path

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/Application.java
+++ b/src/main/java/com/github/jbence1994/webshop/Application.java
@@ -1,7 +1,7 @@
 package com.github.jbence1994.webshop;
 
 import com.github.jbence1994.webshop.photo.FileExtensionsConfig;
-import com.github.jbence1994.webshop.photo.ProductPhotosUploadDirectoryPathConfig;
+import com.github.jbence1994.webshop.photo.ProductPhotosUploadDirectoryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @SpringBootApplication
 @EnableConfigurationProperties(value = {
         FileExtensionsConfig.class,
-        ProductPhotosUploadDirectoryPathConfig.class
+        ProductPhotosUploadDirectoryConfig.class
 })
 public class Application {
 

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoResourceLocationConfig.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoResourceLocationConfig.java
@@ -8,11 +8,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @AllArgsConstructor
 public class PhotoResourceLocationConfig implements WebMvcConfigurer {
-    private final ProductPhotosUploadDirectoryPathConfig productPhotosUploadDirectoryPathConfig;
+    private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        var path = productPhotosUploadDirectoryPathConfig.getPath();
+        var path = productPhotosUploadDirectoryConfig.getPath();
 
         registry
                 .addResourceHandler(path + "/**")

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoUrlBuilder.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoUrlBuilder.java
@@ -7,12 +7,12 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @Component
 @AllArgsConstructor
 public class PhotoUrlBuilder {
-    private final ProductPhotosUploadDirectoryPathConfig productPhotosUploadDirectoryPathConfig;
+    private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
 
     public String buildUrl(String fileName) {
         return ServletUriComponentsBuilder
                 .fromCurrentContextPath()
-                .path(productPhotosUploadDirectoryPathConfig.getPath() + "/")
+                .path(productPhotosUploadDirectoryConfig.getPath() + "/")
                 .path(fileName)
                 .toUriString();
     }

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceImpl.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductPhotoServiceImpl implements ProductPhotoService {
     private final FileExtensionsConfig fileExtensionsConfig;
-    private final ProductPhotosUploadDirectoryPathConfig productPhotosUploadDirectoryPathConfig;
+    private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
     private final ProductQueryService productQueryService;
     private final ProductService productService;
     private final ProductPhotoQueryService productPhotoQueryService;
@@ -29,7 +29,7 @@ public class ProductPhotoServiceImpl implements ProductPhotoService {
             var fileName = photo.generateFileName();
 
             fileUtils.store(
-                    productPhotosUploadDirectoryPathConfig.getPath(),
+                    productPhotosUploadDirectoryConfig.getPath(),
                     fileName,
                     photo.getInputStream()
             );
@@ -54,7 +54,7 @@ public class ProductPhotoServiceImpl implements ProductPhotoService {
             var product = productQueryService.getProduct(productId);
 
             fileUtils.remove(
-                    productPhotosUploadDirectoryPathConfig.getPath(),
+                    productPhotosUploadDirectoryConfig.getPath(),
                     fileName
             );
 

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotosUploadDirectoryConfig.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotosUploadDirectoryConfig.java
@@ -4,9 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "webshop.photo-upload-directory-path.products")
+@ConfigurationProperties(prefix = "webshop.product-photos-upload-directory-config")
 @AllArgsConstructor
 @Getter
-public class ProductPhotosUploadDirectoryPathConfig {
+public class ProductPhotosUploadDirectoryConfig {
     private String path;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,5 +11,5 @@ webshop:
   file-extensions-config:
     allowed-file-extensions: jpg,jpeg,png,bmp
 
-  photo-upload-directory-path:
-    products: ${PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH}
+  product-photos-upload-directory-config:
+    path: ${PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH}

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceImplTests.java
@@ -43,7 +43,7 @@ public class ProductPhotoServiceImplTests {
     private FileExtensionsConfig fileExtensionsConfig;
 
     @Mock
-    private ProductPhotosUploadDirectoryPathConfig productPhotosUploadDirectoryPathConfig;
+    private ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
 
     @Mock
     private ProductQueryService productQueryService;
@@ -68,7 +68,7 @@ public class ProductPhotoServiceImplTests {
         when(photo.getFileExtension()).thenReturn(JPG);
         when(fileExtensionsConfig.getAllowedFileExtensions()).thenReturn(ALLOWED_FILE_EXTENSIONS);
         when(productQueryService.getProduct(any())).thenReturn(product);
-        when(productPhotosUploadDirectoryPathConfig.getPath()).thenReturn(PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH);
+        when(productPhotosUploadDirectoryConfig.getPath()).thenReturn(PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH);
         when(photo.generateFileName()).thenReturn(PHOTO_FILE_NAME);
         when(photo.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[FILE_SIZE.intValue()]));
         doNothing().when(productService).updateProduct(any());


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Bugfixing the misconfigured product photos upload path in `application.yaml` and the config property class.