### PR TITLE
Adding `@GeneratedColumn` annotation to immediately fetch `created_at` column value when a cart is created

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/cart/Cart.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/Cart.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.GeneratedColumn;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -34,6 +35,7 @@ public class Cart {
     private UUID id;
 
     @Column(insertable = false, updatable = false)
+    @GeneratedColumn("created_at")
     private LocalDate createdAt;
 
     @OneToMany(mappedBy = "cart", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Adding `@GeneratedColumn` annotation to immediately fetch `created_at` column value when a cart is created.