### PR TITLE
Removing Template Method pattern from PhotoService, due to uploading a Profile Photo requires different steps

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/photo/DownloadPhotoDto.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/DownloadPhotoDto.java
@@ -1,4 +1,0 @@
-package com.github.jbence1994.webshop.photo;
-
-public record DownloadPhotoDto(String fileName) {
-}

--- a/src/main/java/com/github/jbence1994/webshop/photo/FileExtensionValidator.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/FileExtensionValidator.java
@@ -1,5 +1,5 @@
 package com.github.jbence1994.webshop.photo;
 
 public interface FileExtensionValidator {
-    void validate(UploadPhotoDto photo);
+    void validate(UploadPhoto photo);
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/FileExtensionValidatorImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/FileExtensionValidatorImpl.java
@@ -9,7 +9,7 @@ public class FileExtensionValidatorImpl implements FileExtensionValidator {
     private final FileExtensionsConfig fileExtensionsConfig;
 
     @Override
-    public void validate(UploadPhotoDto photo) {
+    public void validate(UploadPhoto photo) {
         var fileExtension = photo.getFileExtension();
 
         if (!hasValidExtension(fileExtension)) {

--- a/src/main/java/com/github/jbence1994/webshop/photo/Photo.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/Photo.java
@@ -1,5 +1,0 @@
-package com.github.jbence1994.webshop.photo;
-
-public interface Photo {
-    String getFileName();
-}

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public interface PhotoMapper {
 
     @Mapping(target = "inputStreamBytes", expression = "java(getBytes(file))")
-    UploadPhotoDto toDto(MultipartFile file);
+    UploadPhoto toDto(MultipartFile file);
 
     default byte[] getBytes(MultipartFile file) {
         try {

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public interface PhotoMapper {
 
     @Mapping(target = "inputStreamBytes", expression = "java(getBytes(file))")
-    UploadPhoto toDto(MultipartFile file);
+    UploadPhoto toUploadPhoto(MultipartFile file);
 
     default byte[] getBytes(MultipartFile file) {
         try {

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoMapper.java
@@ -1,10 +1,14 @@
 package com.github.jbence1994.webshop.photo;
 
+import org.mapstruct.Context;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface PhotoMapper {
@@ -19,4 +23,11 @@ public interface PhotoMapper {
             throw new ProductPhotoUploadException();
         }
     }
+
+    @IterableMapping(qualifiedByName = "toPhotoResponse")
+    List<PhotoResponse> toPhotoResponses(List<ProductPhoto> photos, @Context PhotoUrlBuilder photoUrlBuilder);
+
+    @Named("toPhotoResponse")
+    @Mapping(target = "url", expression = "java(photoUrlBuilder.buildUrl(photo.getFileName()))")
+    PhotoResponse toPhotoResponse(ProductPhoto photo, @Context PhotoUrlBuilder photoUrlBuilder);
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoService.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoService.java
@@ -1,73 +1,11 @@
 package com.github.jbence1994.webshop.photo;
 
-import lombok.AllArgsConstructor;
-
 import java.util.List;
 
-@AllArgsConstructor
-public abstract class PhotoService<Entity, PhotoEntity extends Photo> {
-    private final FileExtensionValidator fileExtensionValidator;
-    private final FileNameGenerator fileNameGenerator;
-    private final FileUtils fileUtils;
+public interface PhotoService {
+    DownloadPhotoDto uploadPhoto(Long id, UploadPhotoDto uploadPhotoDto);
 
-    protected abstract String getPhotosUploadDirectoryPath();
+    List<DownloadPhotoDto> getPhotos(Long id);
 
-    protected abstract Entity getEntity(Long entityId);
-
-    protected abstract void updateEntity(Entity entity);
-
-    protected abstract void addPhotoToEntity(Entity entity, String fileName);
-
-    protected abstract void removePhotoFromEntity(Entity entity, String fileName);
-
-    protected abstract List<PhotoEntity> getEntityPhotos(Long entityId);
-
-    protected abstract RuntimeException photoUploadException();
-
-    protected abstract RuntimeException photoDeletionException();
-
-    public DownloadPhotoDto uploadPhoto(Long entityId, UploadPhotoDto uploadPhotoDto) {
-        try {
-            fileExtensionValidator.validate(uploadPhotoDto);
-
-            var entity = getEntity(entityId);
-
-            var fileName = fileNameGenerator.generate(uploadPhotoDto.getFileExtension());
-
-            fileUtils.store(
-                    getPhotosUploadDirectoryPath(),
-                    fileName,
-                    uploadPhotoDto.getInputStream()
-            );
-
-            addPhotoToEntity(entity, fileName);
-            updateEntity(entity);
-
-            return new DownloadPhotoDto(fileName);
-        } catch (FileUploadException exception) {
-            throw photoUploadException();
-        }
-    }
-
-    public List<DownloadPhotoDto> getPhotos(Long entityId) {
-        return getEntityPhotos(entityId).stream()
-                .map(photoEntity -> new DownloadPhotoDto(photoEntity.getFileName()))
-                .toList();
-    }
-
-    public void deletePhoto(Long entityId, String fileName) {
-        try {
-            var entity = getEntity(entityId);
-
-            fileUtils.remove(
-                    getPhotosUploadDirectoryPath(),
-                    fileName
-            );
-
-            removePhotoFromEntity(entity, fileName);
-            updateEntity(entity);
-        } catch (FileDeletionException exception) {
-            throw photoDeletionException();
-        }
-    }
+    void deletePhoto(Long id, String fileName);
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/PhotoService.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/PhotoService.java
@@ -1,11 +1,7 @@
 package com.github.jbence1994.webshop.photo;
 
-import java.util.List;
-
 public interface PhotoService {
-    DownloadPhotoDto uploadPhoto(Long id, UploadPhotoDto uploadPhotoDto);
-
-    List<DownloadPhotoDto> getPhotos(Long id);
+    String uploadPhoto(Long id, UploadPhoto uploadPhoto);
 
     void deletePhoto(Long id, String fileName);
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhoto.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhoto.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class ProductPhoto implements Photo {
+public class ProductPhoto {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,9 +30,4 @@ public class ProductPhoto implements Photo {
     private Product product;
 
     private String fileName;
-
-    @Override
-    public String getFileName() {
-        return fileName;
-    }
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
@@ -1,7 +1,6 @@
 package com.github.jbence1994.webshop.photo;
 
-import com.github.jbence1994.webshop.product.Product;
-import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -18,12 +17,21 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/products/{productId}/photos")
-@AllArgsConstructor
 @Validated
 public class ProductPhotoController {
-    private final PhotoService<Product, ProductPhoto> productPhotoService;
+    private final PhotoService productPhotoService;
     private final PhotoMapper photoMapper;
     private final PhotoUrlBuilder photoUrlBuilder;
+
+    public ProductPhotoController(
+            @Qualifier("productPhotoService") final PhotoService productPhotoService,
+            final PhotoMapper photoMapper,
+            final PhotoUrlBuilder photoUrlBuilder
+    ) {
+        this.productPhotoService = productPhotoService;
+        this.photoMapper = photoMapper;
+        this.photoUrlBuilder = photoUrlBuilder;
+    }
 
     @PostMapping
     public ResponseEntity<PhotoResponse> uploadProductPhoto(

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
@@ -41,14 +41,12 @@ public class ProductPhotoController {
             @PathVariable Long productId,
             @FileNotEmpty @RequestParam("file") MultipartFile file
     ) {
-        var uploadPhoto = photoMapper.toDto(file);
+        var uploadPhoto = photoMapper.toUploadPhoto(file);
         var uploadedPhotoFileName = photoService.uploadPhoto(productId, uploadPhoto);
 
         var url = photoUrlBuilder.buildUrl(uploadedPhotoFileName);
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(new PhotoResponse(uploadedPhotoFileName, url));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new PhotoResponse(uploadedPhotoFileName, url));
 
     }
 

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoController.java
@@ -53,16 +53,7 @@ public class ProductPhotoController {
     @GetMapping
     public List<PhotoResponse> getProductPhotos(@PathVariable Long productId) {
         var productPhotos = productPhotoQueryService.getProductPhotos(productId);
-
-        // FIXME: Use Mapstruct here.
-        return productPhotos.stream()
-                .map(productPhoto -> {
-                    var fileName = productPhoto.getFileName();
-                    var url = photoUrlBuilder.buildUrl(fileName);
-
-                    return new PhotoResponse(fileName, url);
-                })
-                .toList();
+        return photoMapper.toPhotoResponses(productPhotos, photoUrlBuilder);
     }
 
     @DeleteMapping("/{fileName}")

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoService.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoService.java
@@ -5,13 +5,10 @@ import com.github.jbence1994.webshop.product.ProductService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @AllArgsConstructor
 public class ProductPhotoService implements PhotoService {
     private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
-    private final ProductPhotoQueryService productPhotoQueryService;
     private final ProductQueryService productQueryService;
     private final ProductService productService;
     private final FileExtensionValidator fileExtensionValidator;
@@ -19,34 +16,27 @@ public class ProductPhotoService implements PhotoService {
     private final FileUtils fileUtils;
 
     @Override
-    public DownloadPhotoDto uploadPhoto(Long productId, UploadPhotoDto uploadPhotoDto) {
+    public String uploadPhoto(Long productId, UploadPhoto uploadPhoto) {
         try {
-            fileExtensionValidator.validate(uploadPhotoDto);
+            fileExtensionValidator.validate(uploadPhoto);
 
             var product = productQueryService.getProduct(productId);
 
-            var fileName = fileNameGenerator.generate(uploadPhotoDto.getFileExtension());
+            var fileName = fileNameGenerator.generate(uploadPhoto.getFileExtension());
 
             fileUtils.store(
                     productPhotosUploadDirectoryConfig.getPath(),
                     fileName,
-                    uploadPhotoDto.getInputStream()
+                    uploadPhoto.getInputStream()
             );
 
             product.addPhoto(fileName);
             productService.updateProduct(product);
 
-            return new DownloadPhotoDto(fileName);
+            return fileName;
         } catch (FileUploadException exception) {
             throw new ProductPhotoUploadException();
         }
-    }
-
-    @Override
-    public List<DownloadPhotoDto> getPhotos(Long productId) {
-        return productPhotoQueryService.getProductPhotos(productId).stream()
-                .map(productPhoto -> new DownloadPhotoDto(productPhoto.getFileName()))
-                .toList();
     }
 
     @Override

--- a/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoService.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/ProductPhotoService.java
@@ -1,74 +1,68 @@
 package com.github.jbence1994.webshop.photo;
 
-import com.github.jbence1994.webshop.product.Product;
 import com.github.jbence1994.webshop.product.ProductQueryService;
-import com.github.jbence1994.webshop.product.ProductRepository;
+import com.github.jbence1994.webshop.product.ProductService;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class ProductPhotoService extends PhotoService<Product, ProductPhoto> {
+@AllArgsConstructor
+public class ProductPhotoService implements PhotoService {
     private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
     private final ProductPhotoQueryService productPhotoQueryService;
     private final ProductQueryService productQueryService;
-    private final ProductRepository productRepository;
+    private final ProductService productService;
+    private final FileExtensionValidator fileExtensionValidator;
+    private final FileNameGenerator fileNameGenerator;
+    private final FileUtils fileUtils;
 
-    public ProductPhotoService(
-            final FileExtensionValidator fileExtensionValidator,
-            final FileNameGenerator fileNameGenerator,
-            final FileUtils fileUtils,
+    @Override
+    public DownloadPhotoDto uploadPhoto(Long productId, UploadPhotoDto uploadPhotoDto) {
+        try {
+            fileExtensionValidator.validate(uploadPhotoDto);
 
-            final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig,
-            final ProductPhotoQueryService productPhotoQueryService,
-            final ProductQueryService productQueryService,
-            final ProductRepository productRepository
-    ) {
-        super(fileExtensionValidator, fileNameGenerator, fileUtils);
+            var product = productQueryService.getProduct(productId);
 
-        this.productPhotosUploadDirectoryConfig = productPhotosUploadDirectoryConfig;
-        this.productPhotoQueryService = productPhotoQueryService;
-        this.productQueryService = productQueryService;
-        this.productRepository = productRepository;
+            var fileName = fileNameGenerator.generate(uploadPhotoDto.getFileExtension());
+
+            fileUtils.store(
+                    productPhotosUploadDirectoryConfig.getPath(),
+                    fileName,
+                    uploadPhotoDto.getInputStream()
+            );
+
+            product.addPhoto(fileName);
+            productService.updateProduct(product);
+
+            return new DownloadPhotoDto(fileName);
+        } catch (FileUploadException exception) {
+            throw new ProductPhotoUploadException();
+        }
     }
 
     @Override
-    public String getPhotosUploadDirectoryPath() {
-        return productPhotosUploadDirectoryConfig.getPath();
+    public List<DownloadPhotoDto> getPhotos(Long productId) {
+        return productPhotoQueryService.getProductPhotos(productId).stream()
+                .map(productPhoto -> new DownloadPhotoDto(productPhoto.getFileName()))
+                .toList();
     }
 
     @Override
-    public Product getEntity(Long productId) {
-        return productQueryService.getProduct(productId);
-    }
+    public void deletePhoto(Long productId, String fileName) {
+        try {
+            var product = productQueryService.getProduct(productId);
 
-    @Override
-    public void updateEntity(Product product) {
-        productRepository.save(product);
-    }
+            fileUtils.remove(
+                    productPhotosUploadDirectoryConfig.getPath(),
+                    fileName
+            );
 
-    @Override
-    public void addPhotoToEntity(Product product, String fileName) {
-        product.addPhoto(fileName);
-    }
-
-    @Override
-    public void removePhotoFromEntity(Product product, String fileName) {
-        product.removePhoto(fileName);
-    }
-
-    @Override
-    public List<ProductPhoto> getEntityPhotos(Long productId) {
-        return productPhotoQueryService.getProductPhotos(productId);
-    }
-
-    @Override
-    public RuntimeException photoUploadException() {
-        return new ProductPhotoUploadException();
-    }
-
-    @Override
-    public RuntimeException photoDeletionException() {
-        return new ProductPhotoDeletionException();
+            product.removePhoto(fileName);
+            productService.updateProduct(product);
+        } catch (FileDeletionException exception) {
+            throw new ProductPhotoDeletionException();
+        }
     }
 }

--- a/src/main/java/com/github/jbence1994/webshop/photo/UploadPhoto.java
+++ b/src/main/java/com/github/jbence1994/webshop/photo/UploadPhoto.java
@@ -13,7 +13,7 @@ import java.io.InputStream;
 @NoArgsConstructor
 @Getter
 @Setter
-public class UploadPhotoDto {
+public class UploadPhoto {
     private boolean isEmpty;
     private String originalFilename;
     private Long size;

--- a/src/main/java/com/github/jbence1994/webshop/product/ProductService.java
+++ b/src/main/java/com/github/jbence1994/webshop/product/ProductService.java
@@ -2,4 +2,6 @@ package com.github.jbence1994.webshop.product;
 
 public interface ProductService {
     void createProduct(Product product);
+
+    void updateProduct(Product product);
 }

--- a/src/main/java/com/github/jbence1994/webshop/product/ProductServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/product/ProductServiceImpl.java
@@ -10,6 +10,15 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public void createProduct(Product product) {
+        save(product);
+    }
+
+    @Override
+    public void updateProduct(Product product) {
+        save(product);
+    }
+
+    private void save(Product product) {
         productRepository.save(product);
     }
 }

--- a/src/main/resources/db/migration/V1__database_schema.sql
+++ b/src/main/resources/db/migration/V1__database_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS product_photos
     id         BIGINT      NOT NULL PRIMARY KEY AUTO_INCREMENT,
     product_id BIGINT      NOT NULL,
     file_name  VARCHAR(41) NOT NULL UNIQUE,
-    CONSTRAINT fk_product_photos_products
+    CONSTRAINT fk_products_product_photos
         FOREIGN KEY (product_id) REFERENCES products (id)
             ON DELETE CASCADE
             ON UPDATE CASCADE

--- a/src/test/java/com/github/jbence1994/webshop/photo/DownloadPhotoDtoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/DownloadPhotoDtoTestObject.java
@@ -1,9 +1,0 @@
-package com.github.jbence1994.webshop.photo;
-
-import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_FILE_NAME;
-
-public class DownloadPhotoDtoTestObject {
-    public static DownloadPhotoDto downloadPhotoDto() {
-        return new DownloadPhotoDto(PHOTO_FILE_NAME);
-    }
-}

--- a/src/test/java/com/github/jbence1994/webshop/photo/FileExtensionValidatorImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/FileExtensionValidatorImplTests.java
@@ -3,13 +3,25 @@ package com.github.jbence1994.webshop.photo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.stream.Stream;
+
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.ALLOWED_FILE_EXTENSIONS;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.jpegUploadPhotoDto;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.tiffUploadPhotoDto;
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.BMP;
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.JPEG;
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.JPG;
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PNG;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.bmpUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.jpegUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.jpgUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.pngUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.tiffUploadPhoto;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -25,21 +37,34 @@ public class FileExtensionValidatorImplTests {
     @InjectMocks
     private FileExtensionValidatorImpl fileExtensionValidator;
 
+    private static Stream<Arguments> uploadPhotoParams() {
+        return Stream.of(
+                Arguments.of(JPEG, jpegUploadPhoto()),
+                Arguments.of(JPG, jpgUploadPhoto()),
+                Arguments.of(PNG, pngUploadPhoto()),
+                Arguments.of(BMP, bmpUploadPhoto())
+        );
+    }
+
     @BeforeEach
     public void setUp() {
         when(fileExtensionsConfig.getAllowedFileExtensions()).thenReturn(ALLOWED_FILE_EXTENSIONS);
     }
 
-    @Test
-    public void validateTest_HappyPath() {
-        assertDoesNotThrow(() -> fileExtensionValidator.validate(jpegUploadPhotoDto()));
+    @ParameterizedTest(name = "{index} => {0}")
+    @MethodSource("uploadPhotoParams")
+    public void validateTests_HappyPath(
+            String testCase,
+            UploadPhoto uploadPhoto
+    ) {
+        assertDoesNotThrow(() -> fileExtensionValidator.validate(uploadPhoto));
     }
 
     @Test
     public void validateTest_UnhappyPath_InvalidFileExtensionException() {
         var result = assertThrows(
                 InvalidFileExtensionException.class,
-                () -> fileExtensionValidator.validate(tiffUploadPhotoDto()));
+                () -> fileExtensionValidator.validate(tiffUploadPhoto()));
 
         assertThat(result.getMessage(), equalTo("Invalid file extension: .tiff"));
     }

--- a/src/test/java/com/github/jbence1994/webshop/photo/PhotoMapperTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/PhotoMapperTests.java
@@ -20,11 +20,11 @@ public class PhotoMapperTests {
     private final MultipartFile multipartFile = mock(MultipartFile.class);
 
     @Test
-    public void toDtoTest_HappyPath() throws IOException {
+    public void toUploadPhotoTest_HappyPath() throws IOException {
         var expectedBytes = new byte[]{1, 2, 3, 4, 5};
         when(multipartFile.getBytes()).thenReturn(expectedBytes);
 
-        var result = mapper.toDto(multipartFile);
+        var result = mapper.toUploadPhoto(multipartFile);
 
         assertThat(result.getInputStreamBytes(), is(equalTo(expectedBytes)));
 
@@ -32,12 +32,12 @@ public class PhotoMapperTests {
     }
 
     @Test
-    public void toDtoTest_UnhappyPath_IOException() throws IOException {
+    public void toUploadPhotoTest_UnhappyPath_IOException() throws IOException {
         when(multipartFile.getBytes()).thenThrow(new IOException("Disk error."));
 
         var result = assertThrows(
                 ProductPhotoUploadException.class,
-                () -> mapper.toDto(multipartFile)
+                () -> mapper.toUploadPhoto(multipartFile)
         );
 
         assertThat(result.getMessage(), equalTo("The photo could not be uploaded successfully."));

--- a/src/test/java/com/github/jbence1994/webshop/photo/PhotoResponseTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/PhotoResponseTestObject.java
@@ -1,0 +1,13 @@
+package com.github.jbence1994.webshop.photo;
+
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_FILE_NAME;
+import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_URL;
+
+public final class PhotoResponseTestObject {
+    public static PhotoResponse photoResponse() {
+        return new PhotoResponse(
+                PHOTO_FILE_NAME,
+                PHOTO_URL
+        );
+    }
+}

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import java.util.List;
 
 import static com.github.jbence1994.webshop.photo.MultipartFileTestObject.multipartFile;
+import static com.github.jbence1994.webshop.photo.PhotoResponseTestObject.photoResponse;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_FILE_NAME;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_URL;
 import static com.github.jbence1994.webshop.photo.ProductPhotoTestObject.productPhoto;
@@ -58,6 +59,7 @@ public class ProductPhotoControllerTests {
     @Test
     public void getProductPhotosTest() {
         when(productPhotoQueryService.getProductPhotos(any())).thenReturn(List.of(productPhoto()));
+        when(photoMapper.toPhotoResponses(any(), any())).thenReturn(List.of(photoResponse()));
 
         var result = productPhotoController.getProductPhotos(1L);
 

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
@@ -9,11 +9,11 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
-import static com.github.jbence1994.webshop.photo.DownloadPhotoDtoTestObject.downloadPhotoDto;
 import static com.github.jbence1994.webshop.photo.MultipartFileTestObject.multipartFile;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_FILE_NAME;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_URL;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.jpegUploadPhotoDto;
+import static com.github.jbence1994.webshop.photo.ProductPhotoTestObject.productPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.jpegUploadPhoto;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -27,7 +27,10 @@ import static org.mockito.Mockito.when;
 public class ProductPhotoControllerTests {
 
     @Mock
-    private PhotoService productPhotoService;
+    private PhotoService photoService;
+
+    @Mock
+    private ProductPhotoQueryService productPhotoQueryService;
 
     @Mock
     private PhotoMapper photoMapper;
@@ -40,8 +43,8 @@ public class ProductPhotoControllerTests {
 
     @Test
     public void uploadProductPhotoTest() {
-        when(photoMapper.toDto(any())).thenReturn(jpegUploadPhotoDto());
-        when(productPhotoService.uploadPhoto(any(), any())).thenReturn(downloadPhotoDto());
+        when(photoMapper.toDto(any())).thenReturn(jpegUploadPhoto());
+        when(photoService.uploadPhoto(any(), any())).thenReturn(PHOTO_FILE_NAME);
         when(photoUrlBuilder.buildUrl(any())).thenReturn(PHOTO_URL);
 
         var result = productPhotoController.uploadProductPhoto(1L, multipartFile());
@@ -54,7 +57,7 @@ public class ProductPhotoControllerTests {
 
     @Test
     public void getProductPhotosTest() {
-        when(productPhotoService.getPhotos(any())).thenReturn(List.of(downloadPhotoDto()));
+        when(productPhotoQueryService.getProductPhotos(any())).thenReturn(List.of(productPhoto()));
 
         var result = productPhotoController.getProductPhotos(1L);
 
@@ -63,7 +66,7 @@ public class ProductPhotoControllerTests {
 
     @Test
     public void deleteProductPhotoTest() {
-        doNothing().when(productPhotoService).deletePhoto(any(), any());
+        doNothing().when(photoService).deletePhoto(any(), any());
 
         var result = productPhotoController.deleteProductPhoto(1L, PHOTO_FILE_NAME);
 

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
@@ -43,7 +43,7 @@ public class ProductPhotoControllerTests {
 
     @Test
     public void uploadProductPhotoTest() {
-        when(photoMapper.toDto(any())).thenReturn(jpegUploadPhoto());
+        when(photoMapper.toUploadPhoto(any())).thenReturn(jpegUploadPhoto());
         when(photoService.uploadPhoto(any(), any())).thenReturn(PHOTO_FILE_NAME);
         when(photoUrlBuilder.buildUrl(any())).thenReturn(PHOTO_URL);
 

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoControllerTests.java
@@ -1,6 +1,5 @@
 package com.github.jbence1994.webshop.photo;
 
-import com.github.jbence1994.webshop.product.Product;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class ProductPhotoControllerTests {
 
     @Mock
-    private PhotoService<Product, ProductPhoto> productPhotoService;
+    private PhotoService productPhotoService;
 
     @Mock
     private PhotoMapper photoMapper;

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoQueryServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoQueryServiceImplTests.java
@@ -42,7 +42,7 @@ public class ProductPhotoQueryServiceImplTests {
     }
 
     @Test
-    public void getProductPhotosTest_UnhappyPath() {
+    public void getProductPhotosTest_UnhappyPath_ProductNotFoundException() {
         doThrow(new ProductNotFoundException(1L)).when(productQueryService).getProduct(any());
 
         var result = assertThrows(

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceTests.java
@@ -2,7 +2,7 @@ package com.github.jbence1994.webshop.photo;
 
 import com.github.jbence1994.webshop.product.Product;
 import com.github.jbence1994.webshop.product.ProductQueryService;
-import com.github.jbence1994.webshop.product.ProductRepository;
+import com.github.jbence1994.webshop.product.ProductService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,16 +44,16 @@ public class ProductPhotoServiceTests {
     private ProductPhotoQueryService productPhotoQueryService;
 
     @Mock
-    private FileExtensionValidator fileExtensionValidator;
-
-    @Mock
     private ProductQueryService productQueryService;
 
     @Mock
-    private FileNameGenerator fileNameGenerator;
+    private ProductService productService;
 
     @Mock
-    private ProductRepository productRepository;
+    private FileExtensionValidator fileExtensionValidator;
+
+    @Mock
+    private FileNameGenerator fileNameGenerator;
 
     @Mock
     private FileUtils fileUtils;
@@ -71,8 +71,7 @@ public class ProductPhotoServiceTests {
         when(fileNameGenerator.generate(any())).thenReturn(PHOTO_FILE_NAME);
         when(productPhotosUploadDirectoryConfig.getPath()).thenReturn(PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH);
         when(uploadPhotoDto.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[FILE_SIZE.intValue()]));
-        when(productRepository.save(any())).thenReturn(product);
-
+        doNothing().when(productService).updateProduct(any());
     }
 
     @Test
@@ -91,7 +90,7 @@ public class ProductPhotoServiceTests {
         verify(uploadPhotoDto, times(1)).getInputStream();
         verify(fileUtils, times(1)).store(any(), any(), any());
         verify(product, times(1)).addPhoto(any());
-        verify(productRepository, times(1)).save(any());
+        verify(productService, times(1)).updateProduct(any());
     }
 
     @Test
@@ -112,7 +111,7 @@ public class ProductPhotoServiceTests {
         verify(uploadPhotoDto, times(1)).getInputStream();
         verify(fileUtils, times(1)).store(any(), any(), any());
         verify(product, never()).addPhoto(any());
-        verify(productRepository, never()).save(any());
+        verify(productService, never()).updateProduct(any());
     }
 
     @Test
@@ -133,7 +132,7 @@ public class ProductPhotoServiceTests {
 
         verify(fileUtils, times(1)).remove(any(), any());
         verify(product, times(1)).removePhoto(any());
-        verify(productRepository, times(1)).save(any());
+        verify(productService, times(1)).updateProduct(any());
     }
 
     @Test
@@ -149,6 +148,6 @@ public class ProductPhotoServiceTests {
 
         verify(fileUtils, times(1)).remove(any(), any());
         verify(product, never()).removePhoto(any());
-        verify(productRepository, never()).save(any());
+        verify(productService, never()).updateProduct(any());
     }
 }

--- a/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/ProductPhotoServiceTests.java
@@ -13,12 +13,10 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.ByteArrayInputStream;
-import java.util.List;
 
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.FILE_SIZE;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PHOTO_FILE_NAME;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PRODUCT_PHOTOS_UPLOAD_DIRECTORY_PATH;
-import static com.github.jbence1994.webshop.photo.ProductPhotoTestObject.productPhoto;
 import static com.github.jbence1994.webshop.product.ProductTestObject.product1;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,9 +39,6 @@ public class ProductPhotoServiceTests {
     private ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
 
     @Mock
-    private ProductPhotoQueryService productPhotoQueryService;
-
-    @Mock
     private ProductQueryService productQueryService;
 
     @Mock
@@ -62,7 +57,7 @@ public class ProductPhotoServiceTests {
     private ProductPhotoService productPhotoService;
 
     private final Product product = spy(product1());
-    private final UploadPhotoDto uploadPhotoDto = mock(UploadPhotoDto.class);
+    private final UploadPhoto uploadPhotoDto = mock(UploadPhoto.class);
 
     @BeforeEach
     public void setUp() {
@@ -81,7 +76,7 @@ public class ProductPhotoServiceTests {
 
         var result = productPhotoService.uploadPhoto(1L, uploadPhotoDto);
 
-        assertThat(result.fileName(), equalTo(PHOTO_FILE_NAME));
+        assertThat(result, equalTo(PHOTO_FILE_NAME));
 
         verify(fileExtensionValidator, times(1)).validate(any());
         verify(productQueryService, times(1)).getProduct(any());
@@ -94,7 +89,7 @@ public class ProductPhotoServiceTests {
     }
 
     @Test
-    public void uploadPhotoTest_UnhappyPath_FileSystemException() {
+    public void uploadPhotoTest_UnhappyPath_ProductPhotoUploadException() {
         doThrow(new FileUploadException("Disk error.")).when(fileUtils).store(any(), any(), any());
 
         var result = assertThrows(
@@ -115,15 +110,6 @@ public class ProductPhotoServiceTests {
     }
 
     @Test
-    public void getPhotosTest_HappyPath() {
-        when(productPhotoQueryService.getProductPhotos(any())).thenReturn(List.of(productPhoto()));
-
-        var result = productPhotoService.getPhotos(1L);
-
-        assertThat(result.size(), equalTo(1));
-    }
-
-    @Test
     public void deletePhotoTest_HappyPath() {
         doNothing().when(fileUtils).remove(any(), any());
         doNothing().when(product).removePhoto(any());
@@ -136,7 +122,7 @@ public class ProductPhotoServiceTests {
     }
 
     @Test
-    public void deletePhotoTest_UnhappyPath_FileSystemException() {
+    public void deletePhotoTest_UnhappyPath_ProductPhotoUploadException() {
         doThrow(new FileDeletionException("Disk error.")).when(fileUtils).remove(any(), any());
 
         var result = assertThrows(

--- a/src/test/java/com/github/jbence1994/webshop/photo/UploadPhotoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/UploadPhotoTestObject.java
@@ -12,29 +12,29 @@ import static com.github.jbence1994.webshop.photo.PhotoTestConstants.ORIGINAL_FI
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.ORIGINAL_FILE_NAME_PNG;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.ORIGINAL_FILE_NAME_TIFF;
 
-public final class UploadPhotoDtoTestObject {
-    public static UploadPhotoDto jpegUploadPhotoDto() {
-        return buildUploadPhotoDto(ORIGINAL_FILE_NAME_JPEG, CONTENT_TYPE_IMAGE_JPEG);
+public final class UploadPhotoTestObject {
+    public static UploadPhoto jpegUploadPhoto() {
+        return buildUploadPhoto(ORIGINAL_FILE_NAME_JPEG, CONTENT_TYPE_IMAGE_JPEG);
     }
 
-    public static UploadPhotoDto jpgUploadPhotoDto() {
-        return buildUploadPhotoDto(ORIGINAL_FILE_NAME_JPG, CONTENT_TYPE_IMAGE_JPG);
+    public static UploadPhoto jpgUploadPhoto() {
+        return buildUploadPhoto(ORIGINAL_FILE_NAME_JPG, CONTENT_TYPE_IMAGE_JPG);
     }
 
-    public static UploadPhotoDto pngUploadPhotoDto() {
-        return buildUploadPhotoDto(ORIGINAL_FILE_NAME_PNG, CONTENT_TYPE_IMAGE_PNG);
+    public static UploadPhoto pngUploadPhoto() {
+        return buildUploadPhoto(ORIGINAL_FILE_NAME_PNG, CONTENT_TYPE_IMAGE_PNG);
     }
 
-    public static UploadPhotoDto bmpUploadPhotoDto() {
-        return buildUploadPhotoDto(ORIGINAL_FILE_NAME_BMP, CONTENT_TYPE_IMAGE_BMP);
+    public static UploadPhoto bmpUploadPhoto() {
+        return buildUploadPhoto(ORIGINAL_FILE_NAME_BMP, CONTENT_TYPE_IMAGE_BMP);
     }
 
-    public static UploadPhotoDto tiffUploadPhotoDto() {
-        return buildUploadPhotoDto(ORIGINAL_FILE_NAME_TIFF, CONTENT_TYPE_IMAGE_TIFF);
+    public static UploadPhoto tiffUploadPhoto() {
+        return buildUploadPhoto(ORIGINAL_FILE_NAME_TIFF, CONTENT_TYPE_IMAGE_TIFF);
     }
 
-    private static UploadPhotoDto buildUploadPhotoDto(String originalFilename, String contentType) {
-        return new UploadPhotoDto(
+    private static UploadPhoto buildUploadPhoto(String originalFilename, String contentType) {
+        return new UploadPhoto(
                 false,
                 originalFilename,
                 FILE_SIZE,

--- a/src/test/java/com/github/jbence1994/webshop/photo/UploadPhotoTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/photo/UploadPhotoTests.java
@@ -10,43 +10,43 @@ import static com.github.jbence1994.webshop.photo.PhotoTestConstants.BMP;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.JPEG;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.JPG;
 import static com.github.jbence1994.webshop.photo.PhotoTestConstants.PNG;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.bmpUploadPhotoDto;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.jpegUploadPhotoDto;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.jpgUploadPhotoDto;
-import static com.github.jbence1994.webshop.photo.UploadPhotoDtoTestObject.pngUploadPhotoDto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.bmpUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.jpegUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.jpgUploadPhoto;
+import static com.github.jbence1994.webshop.photo.UploadPhotoTestObject.pngUploadPhoto;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-public class UploadPhotoDtoTests {
-    private static Stream<Arguments> uploadPhotoDtoParams() {
+public class UploadPhotoTests {
+    private static Stream<Arguments> uploadPhotoParams() {
         return Stream.of(
-                Arguments.of(JPEG, jpegUploadPhotoDto()),
-                Arguments.of(JPG, jpgUploadPhotoDto()),
-                Arguments.of(PNG, pngUploadPhotoDto()),
-                Arguments.of(BMP, bmpUploadPhotoDto())
+                Arguments.of(JPEG, jpegUploadPhoto()),
+                Arguments.of(JPG, jpgUploadPhoto()),
+                Arguments.of(PNG, pngUploadPhoto()),
+                Arguments.of(BMP, bmpUploadPhoto())
         );
     }
 
     @ParameterizedTest(name = "{index} => {0}")
-    @MethodSource("uploadPhotoDtoParams")
+    @MethodSource("uploadPhotoParams")
     public void getInputStreamTests(
             String testCase,
-            UploadPhotoDto uploadPhotoDto
+            UploadPhoto uploadPhoto
     ) {
-        var result = uploadPhotoDto.getInputStream();
+        var result = uploadPhoto.getInputStream();
 
         assertThat(result, not(nullValue()));
     }
 
     @ParameterizedTest(name = "{index} => {0}")
-    @MethodSource("uploadPhotoDtoParams")
+    @MethodSource("uploadPhotoParams")
     public void getFileExtensionTests(
             String extension,
-            UploadPhotoDto uploadPhotoDto
+            UploadPhoto uploadPhoto
     ) {
-        var result = uploadPhotoDto.getFileExtension();
+        var result = uploadPhoto.getFileExtension();
 
         assertThat(result, equalTo(extension));
     }

--- a/src/test/java/com/github/jbence1994/webshop/product/ProductServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/product/ProductServiceImplTests.java
@@ -26,4 +26,11 @@ public class ProductServiceImplTests {
 
         assertDoesNotThrow(() -> productService.createProduct(product1()));
     }
+
+    @Test
+    public void updateProductTest() {
+        when(productRepository.save(any())).thenReturn(product1());
+
+        assertDoesNotThrow(() -> productService.updateProduct(product1()));
+    }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Removing Template Method pattern from PhotoService and define it as an interface, due to uploading a Profile Photo requires different steps than a Product Photo: only one Profile Photo can be uploaded, replacing the previously uploaded photo (need to be deleted from the file system).