### PR TITLE
Adding `created_at` column for product photos

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/image/ProductPhoto.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProductPhoto.java
@@ -1,6 +1,7 @@
 package com.github.jbence1994.webshop.image;
 
 import com.github.jbence1994.webshop.product.Product;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -13,6 +14,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.GeneratedColumn;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "product_photos")
@@ -31,4 +35,8 @@ public class ProductPhoto {
     private Product product;
 
     private String fileName;
+
+    @Column(insertable = false, updatable = false)
+    @GeneratedColumn("created_at")
+    private LocalDateTime createdAt;
 }

--- a/src/main/resources/db/migration/V1__database_schema.sql
+++ b/src/main/resources/db/migration/V1__database_schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS product_photos
     id         BIGINT      NOT NULL PRIMARY KEY AUTO_INCREMENT,
     product_id BIGINT      NOT NULL,
     file_name  VARCHAR(41) NOT NULL UNIQUE,
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_products_product_photos
         FOREIGN KEY (product_id) REFERENCES products (id)
             ON DELETE CASCADE

--- a/src/test/java/com/github/jbence1994/webshop/image/ProductPhotoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/image/ProductPhotoTestObject.java
@@ -1,5 +1,7 @@
 package com.github.jbence1994.webshop.image;
 
+import java.time.LocalDateTime;
+
 import static com.github.jbence1994.webshop.image.ImageTestConstants.PHOTO_FILE_NAME;
 import static com.github.jbence1994.webshop.product.ProductTestObject.product1;
 
@@ -8,7 +10,8 @@ public final class ProductPhotoTestObject {
         return new ProductPhoto(
                 1L,
                 product1(),
-                PHOTO_FILE_NAME
+                PHOTO_FILE_NAME,
+                LocalDateTime.now()
         );
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Adding `created_at` column for product photos.