### PR TITLE
Removing the previous avatar from the file system if a user has one uploaded already

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarService.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarService.java
@@ -22,6 +22,13 @@ public class ProfileAvatarService implements ImageService {
 
             var user = userQueryService.getUser(userId);
 
+            if (user.hasProfileAvatar()) {
+                fileUtils.remove(
+                        profileAvatarUploadDirectoryConfig.getPath(),
+                        user.getProfileAvatar()
+                );
+            }
+
             var fileName = fileNameGenerator.generate(uploadImage.getFileExtension());
 
             fileUtils.store(

--- a/src/main/java/com/github/jbence1994/webshop/user/User.java
+++ b/src/main/java/com/github/jbence1994/webshop/user/User.java
@@ -50,4 +50,8 @@ public class User {
     public String getProfileAvatar() {
         return profile.getAvatarFileName();
     }
+
+    public boolean hasProfileAvatar() {
+        return profile.getAvatarFileName() != null;
+    }
 }

--- a/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarServiceTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarServiceTests.java
@@ -18,6 +18,7 @@ import static com.github.jbence1994.webshop.image.ImageTestConstants.AVATAR_FILE
 import static com.github.jbence1994.webshop.image.ImageTestConstants.FILE_SIZE;
 import static com.github.jbence1994.webshop.image.ImageTestConstants.PROFILE_AVATAR_UPLOAD_DIRECTORY_PATH;
 import static com.github.jbence1994.webshop.user.UserTestObject.user;
+import static com.github.jbence1994.webshop.user.UserTestObject.userWithAvatar;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,6 +58,7 @@ public class ProfileAvatarServiceTests {
     private ProfileAvatarService profileAvatarService;
 
     private final User userWithoutAvatar = spy(user());
+    private final User user = spy(userWithAvatar());
     private final UploadImage uploadImage = mock(UploadImage.class);
 
     @BeforeEach
@@ -70,7 +72,8 @@ public class ProfileAvatarServiceTests {
     }
 
     @Test
-    public void uploadImageTest_HappyPath() {
+    public void uploadImageTest_HappyPath_UserDoNotHaveAvatarUploadedYet() {
+        when(userWithoutAvatar.hasProfileAvatar()).thenReturn(false);
         doNothing().when(fileUtils).store(any(), any(), any());
         doNothing().when(userWithoutAvatar).setProfileAvatar(any());
 
@@ -80,11 +83,37 @@ public class ProfileAvatarServiceTests {
 
         verify(fileExtensionValidator, times(1)).validate(any());
         verify(userQueryService, times(1)).getUser(any());
+        verify(userWithoutAvatar, times(1)).hasProfileAvatar();
+        verify(fileUtils, never()).remove(any(), any());
         verify(fileNameGenerator, times(1)).generate(any());
         verify(profileAvatarUploadDirectoryConfig, times(1)).getPath();
         verify(uploadImage, times(1)).getInputStream();
         verify(fileUtils, times(1)).store(any(), any(), any());
         verify(userWithoutAvatar, times(1)).setProfileAvatar(any());
+        verify(userService, times(1)).updateUser(any());
+    }
+
+    @Test
+    public void uploadImageTest_HappyPath_UserDoesHaveAvatarUploadedAlready() {
+        when(userQueryService.getUser(any())).thenReturn(user);
+        when(user.hasProfileAvatar()).thenReturn(true);
+        doNothing().when(fileUtils).remove(any(), any());
+        doNothing().when(fileUtils).store(any(), any(), any());
+        doNothing().when(userWithoutAvatar).setProfileAvatar(any());
+
+        var result = profileAvatarService.uploadImage(1L, uploadImage);
+
+        assertThat(result, equalTo(AVATAR_FILE_NAME));
+
+        verify(fileExtensionValidator, times(1)).validate(any());
+        verify(fileUtils, times(1)).remove(any(), any());
+        verify(userQueryService, times(1)).getUser(any());
+        verify(user, times(1)).hasProfileAvatar();
+        verify(fileNameGenerator, times(1)).generate(any());
+        verify(profileAvatarUploadDirectoryConfig, times(2)).getPath();
+        verify(uploadImage, times(1)).getInputStream();
+        verify(fileUtils, times(1)).store(any(), any(), any());
+        verify(user, times(1)).setProfileAvatar(any());
         verify(userService, times(1)).updateUser(any());
     }
 

--- a/src/test/java/com/github/jbence1994/webshop/user/UserTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/user/UserTests.java
@@ -1,20 +1,54 @@
 package com.github.jbence1994.webshop.user;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static com.github.jbence1994.webshop.image.ImageTestConstants.AVATAR_FILE_NAME;
 import static com.github.jbence1994.webshop.user.UserTestObject.user;
+import static com.github.jbence1994.webshop.user.UserTestObject.userWithAvatar;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class UserTests {
-    private final User userWithoutAvatar = user();
+    private final User user1 = user();
+    private final User user2 = userWithAvatar();
+
+    private static Stream<Arguments> userParams() {
+        return Stream.of(
+                Arguments.of("User with avatar", userWithAvatar(), true),
+                Arguments.of("User without avatar", user(), false)
+        );
+    }
 
     @Test
     public void setProfileAvatarTest() {
-        userWithoutAvatar.setProfileAvatar(AVATAR_FILE_NAME);
+        user1.setProfileAvatar(AVATAR_FILE_NAME);
 
-        assertThat(userWithoutAvatar.getProfile().getAvatarFileName(), not(nullValue()));
+        assertThat(user1.getProfileAvatar(), not(nullValue()));
+    }
+
+    @Test
+    public void getProfileAvatarTest() {
+        var result = user2.getProfileAvatar();
+
+        assertThat(result, not(nullValue()));
+    }
+
+    @ParameterizedTest(name = "{index} => {0}")
+    @MethodSource("userParams")
+    public void hasProfileAvatarTests(
+            String testCase,
+            User user,
+            boolean expectedResult
+    ) {
+        var result = user.hasProfileAvatar();
+
+        assertThat(result, is(expectedResult));
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Removing the previous avatar from the file system if a user has one uploaded already.