### PR TITLE
Fixing `PERCENT_OFF` coupon discount value calculation

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/cart/FixedAmountPriceAdjustmentStrategy.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/FixedAmountPriceAdjustmentStrategy.java
@@ -3,6 +3,7 @@ package com.github.jbence1994.webshop.cart;
 import java.math.BigDecimal;
 
 public class FixedAmountPriceAdjustmentStrategy implements PriceAdjustmentStrategy {
+
     @Override
     public BigDecimal adjustPrice(BigDecimal totalPrice, BigDecimal value) {
         return totalPrice.subtract(value).max(BigDecimal.ZERO);

--- a/src/main/java/com/github/jbence1994/webshop/cart/PercentOffPriceAdjustmentStrategy.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/PercentOffPriceAdjustmentStrategy.java
@@ -9,7 +9,7 @@ public class PercentOffPriceAdjustmentStrategy implements PriceAdjustmentStrateg
     public BigDecimal adjustPrice(BigDecimal totalPrice, BigDecimal value) {
         var discountValue = totalPrice
                 .multiply(value)
-                .setScale(2, RoundingMode.UP);
+                .setScale(2, RoundingMode.DOWN);
 
         return totalPrice.subtract(discountValue);
     }

--- a/src/main/java/com/github/jbence1994/webshop/cart/PercentOffPriceAdjustmentStrategy.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/PercentOffPriceAdjustmentStrategy.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 public class PercentOffPriceAdjustmentStrategy implements PriceAdjustmentStrategy {
+
     @Override
     public BigDecimal adjustPrice(BigDecimal totalPrice, BigDecimal value) {
         var discountValue = totalPrice

--- a/src/main/java/com/github/jbence1994/webshop/cart/PriceAdjustmentStrategyFactory.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/PriceAdjustmentStrategyFactory.java
@@ -1,12 +1,13 @@
 package com.github.jbence1994.webshop.cart;
 
 import com.github.jbence1994.webshop.coupon.DiscountType;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PriceAdjustmentStrategyFactory {
-    private PriceAdjustmentStrategyFactory() {
-    }
 
     private static final Map<DiscountType, PriceAdjustmentStrategy> priceAdjustmentStrategies = Map.of(
             DiscountType.FIXED_AMOUNT, new FixedAmountPriceAdjustmentStrategy(),

--- a/src/test/java/com/github/jbence1994/webshop/cart/CartTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/cart/CartTests.java
@@ -43,7 +43,7 @@ public class CartTests {
         return Stream.of(
                 Arguments.of("Without applied coupon", cartWithTwoItems(), BigDecimal.valueOf(139.98)),
                 Arguments.of("With fixed amount type of applied coupon", cartWithTwoItemsAndFixedAmountTypeOfAppliedCoupon(), BigDecimal.valueOf(134.98)),
-                Arguments.of("With percent off type of applied coupon", cartWithTwoItemsAndPercentOffTypeOfAppliedCoupon(), BigDecimal.valueOf(125.98))
+                Arguments.of("With percent off type of applied coupon", cartWithTwoItemsAndPercentOffTypeOfAppliedCoupon(), BigDecimal.valueOf(125.99))
         );
     }
 


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Rounding the discount value `DOWN` to represent the natural value of the discount percent.