### PR TITLE
Persisting `order_id` when redeeming a coupon during checkout

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/cart/Cart.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/Cart.java
@@ -85,6 +85,10 @@ public class Cart {
         return appliedCoupon != null;
     }
 
+    public String getCouponCode() {
+        return appliedCoupon.getCode();
+    }
+
     public void clear() {
         items.clear();
     }

--- a/src/main/java/com/github/jbence1994/webshop/cart/CartMapper.java
+++ b/src/main/java/com/github/jbence1994/webshop/cart/CartMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapping;
 public interface CartMapper {
 
     @Mapping(target = "totalPrice", expression = "java(cart.calculateTotalPrice())")
-    @Mapping(target = "appliedCoupon", expression = "java(cart.getAppliedCoupon() != null ? cart.getAppliedCoupon().getCode() : null)")
+    @Mapping(target = "appliedCoupon", expression = "java(cart.getAppliedCoupon() != null ? cart.getCouponCode() : null)")
     CartDto toDto(Cart cart);
 
     @Mapping(target = "totalPrice", expression = "java(cartItem.calculateTotalPrice())")

--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
@@ -38,8 +38,11 @@ public class CheckoutServiceImpl implements CheckoutService {
         orderService.createOrder(order);
 
         if (cart.hasCouponApplied()) {
-            // FIXME: For better tracing persist the 'orderId' in the 'user_coupons' table.
-            couponService.redeemCoupon(user.getId(), cart.getAppliedCoupon().getCode());
+            couponService.redeemCoupon(
+                    user.getId(),
+                    cart.getCouponCode(),
+                    order.getId()
+            );
         }
 
         cart.clear();

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
@@ -13,11 +13,12 @@ public interface CouponRepository extends JpaRepository<Coupon, String> {
 
     @Modifying
     @Query(
-            value = "UPDATE user_coupons SET redeemed = 1, redeemed_at = CURRENT_TIMESTAMP WHERE user_id = :userId AND coupon_code = :couponCode",
+            value = "UPDATE user_coupons SET redeemed = 1, redeemed_at = CURRENT_TIMESTAMP, order_id = :orderId WHERE user_id = :userId AND coupon_code = :couponCode",
             nativeQuery = true
     )
     void redeemCoupon(
             @Param("userId") Long userId,
-            @Param("couponCode") String couponCode
+            @Param("couponCode") String couponCode,
+            @Param("orderId") Long orderId
     );
 }

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponService.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponService.java
@@ -1,5 +1,5 @@
 package com.github.jbence1994.webshop.coupon;
 
 public interface CouponService {
-    void redeemCoupon(Long userId, String couponCode);
+    void redeemCoupon(Long userId, String couponCode, Long orderId);
 }

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponServiceImpl.java
@@ -9,7 +9,7 @@ public class CouponServiceImpl implements CouponService {
     private final CouponRepository couponRepository;
 
     @Override
-    public void redeemCoupon(Long userId, String couponCode) {
-        couponRepository.redeemCoupon(userId, couponCode);
+    public void redeemCoupon(Long userId, String couponCode, Long orderId) {
+        couponRepository.redeemCoupon(userId, couponCode, orderId);
     }
 }

--- a/src/test/java/com/github/jbence1994/webshop/cart/CartTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/cart/CartTests.java
@@ -12,6 +12,7 @@ import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithTwoItems
 import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithTwoItemsAndFixedAmountTypeOfAppliedCoupon;
 import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithTwoItemsAndPercentOffTypeOfAppliedCoupon;
 import static com.github.jbence1994.webshop.cart.CartTestObject.emptyCart;
+import static com.github.jbence1994.webshop.coupon.CouponTestConstants.COUPON_2_CODE;
 import static com.github.jbence1994.webshop.product.ProductTestObject.product1;
 import static com.github.jbence1994.webshop.product.ProductTestObject.product2;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -108,6 +109,13 @@ public class CartTests {
         var result = cart.hasCouponApplied();
 
         assertThat(result, is(expectedResult));
+    }
+
+    @Test
+    public void getCouponCodeTest() {
+        var result = cartWithTwoItemsAndFixedAmountTypeOfAppliedCoupon().getCouponCode();
+
+        assertThat(result, equalTo(COUPON_2_CODE));
     }
 
     @Test

--- a/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImplTests.java
@@ -64,7 +64,7 @@ public class CheckoutServiceImplTests {
         verify(cartQueryService, times(1)).getCart(any());
         verify(authService, times(1)).getCurrentUser();
         verify(orderService, times(1)).createOrder(any());
-        verify(couponService, never()).redeemCoupon(any(), any());
+        verify(couponService, never()).redeemCoupon(any(), any(), any());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CheckoutServiceImplTests {
         when(authService.getCurrentUser()).thenReturn(user());
         doNothing().when(orderService).createOrder(any());
         when(loyaltyPointsCalculator.calculateLoyaltyPoints(any())).thenReturn(6);
-        doNothing().when(couponService).redeemCoupon(any(), any());
+        doNothing().when(couponService).redeemCoupon(any(), any(), any());
 
         var result = checkoutService.checkout(checkoutRequest());
 
@@ -83,7 +83,7 @@ public class CheckoutServiceImplTests {
         verify(authService, times(1)).getCurrentUser();
         verify(orderService, times(1)).createOrder(any());
         verify(loyaltyPointsCalculator, times(1)).calculateLoyaltyPoints(any());
-        verify(couponService, times(1)).redeemCoupon(any(), any());
+        verify(couponService, times(1)).redeemCoupon(any(), any(), any());
     }
 
     @Test
@@ -101,6 +101,6 @@ public class CheckoutServiceImplTests {
         verify(authService, never()).getCurrentUser();
         verify(orderService, never()).createOrder(any());
         verify(loyaltyPointsCalculator, never()).calculateLoyaltyPoints(any());
-        verify(couponService, never()).redeemCoupon(any(), any());
+        verify(couponService, never()).redeemCoupon(any(), any(), any());
     }
 }

--- a/src/test/java/com/github/jbence1994/webshop/coupon/CouponServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/coupon/CouponServiceImplTests.java
@@ -24,10 +24,10 @@ public class CouponServiceImplTests {
 
     @Test
     public void getCouponsTest() {
-        doNothing().when(couponRepository).redeemCoupon(any(), any());
+        doNothing().when(couponRepository).redeemCoupon(any(), any(), any());
 
-        assertDoesNotThrow(() -> couponService.redeemCoupon(1L, COUPON_1_CODE));
+        assertDoesNotThrow(() -> couponService.redeemCoupon(1L, COUPON_1_CODE, 1L));
 
-        verify(couponRepository, times(1)).redeemCoupon(any(), any());
+        verify(couponRepository, times(1)).redeemCoupon(any(), any(), any());
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Persisting `order_id` when redeeming a coupon during checkout.