### PR TITLE
Bugfixing Profile Avatar URL building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,8 @@
                         <exclude>com/github/jbence1994/webshop/common/EmailServiceImpl*</exclude>
                         <exclude>com/github/jbence1994/webshop/common/FreeMarkerEmailTemplateBuilder*</exclude>
                         <exclude>com/github/jbence1994/webshop/image/FileSystemUtils*</exclude>
-                        <exclude>com/github/jbence1994/webshop/image/ImageUrlBuilder*</exclude>
+                        <exclude>com/github/jbence1994/webshop/image/ProductPhotoUrlBuilder*</exclude>
+                        <exclude>com/github/jbence1994/webshop/image/ProfileAvatarUrlBuilder*</exclude>
                         <exclude>com/github/jbence1994/webshop/Application*</exclude>
                     </excludes>
                 </configuration>

--- a/src/main/java/com/github/jbence1994/webshop/image/ImageUrlBuilder.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ImageUrlBuilder.java
@@ -1,19 +1,5 @@
 package com.github.jbence1994.webshop.image;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
-@Component
-@RequiredArgsConstructor
-public class ImageUrlBuilder {
-    private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
-
-    public String buildUrl(String fileName) {
-        return ServletUriComponentsBuilder
-                .fromCurrentContextPath()
-                .path(productPhotosUploadDirectoryConfig.path() + "/")
-                .path(fileName)
-                .toUriString();
-    }
+public interface ImageUrlBuilder {
+    String buildUrl(String fileName);
 }

--- a/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoController.java
@@ -27,13 +27,13 @@ public class ProductPhotoController {
     public ProductPhotoController(
             final ProductPhotoQueryService productPhotoQueryService,
             @Qualifier("productPhotoService") final ImageService imageService,
-            final ImageMapper imageMapper,
-            final ImageUrlBuilder imageUrlBuilder
+            @Qualifier("productPhotoUrlBuilder") final ImageUrlBuilder imageUrlBuilder,
+            final ImageMapper imageMapper
     ) {
         this.productPhotoQueryService = productPhotoQueryService;
+        this.imageUrlBuilder = imageUrlBuilder;
         this.imageService = imageService;
         this.imageMapper = imageMapper;
-        this.imageUrlBuilder = imageUrlBuilder;
     }
 
     @PostMapping

--- a/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoController.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoController.java
@@ -20,14 +20,14 @@ import java.util.List;
 @Validated
 public class ProductPhotoController {
     private final ProductPhotoQueryService productPhotoQueryService;
+    private final ImageUrlBuilder imageUrlBuilder;
     private final ImageService imageService;
     private final ImageMapper imageMapper;
-    private final ImageUrlBuilder imageUrlBuilder;
 
     public ProductPhotoController(
             final ProductPhotoQueryService productPhotoQueryService,
-            @Qualifier("productPhotoService") final ImageService imageService,
             @Qualifier("productPhotoUrlBuilder") final ImageUrlBuilder imageUrlBuilder,
+            @Qualifier("productPhotoService") final ImageService imageService,
             final ImageMapper imageMapper
     ) {
         this.productPhotoQueryService = productPhotoQueryService;

--- a/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoUrlBuilder.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProductPhotoUrlBuilder.java
@@ -1,0 +1,20 @@
+package com.github.jbence1994.webshop.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class ProductPhotoUrlBuilder implements ImageUrlBuilder {
+    private final ProductPhotosUploadDirectoryConfig productPhotosUploadDirectoryConfig;
+
+    @Override
+    public String buildUrl(String fileName) {
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path(productPhotosUploadDirectoryConfig.path() + "/")
+                .path(fileName)
+                .toUriString();
+    }
+}

--- a/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
@@ -19,20 +19,20 @@ import org.springframework.web.multipart.MultipartFile;
 @Validated
 public class ProfileAvatarController {
     private final UserQueryService userQueryService;
+    private final ImageUrlBuilder imageUrlBuilder;
     private final ImageService imageService;
     private final ImageMapper imageMapper;
-    private final ImageUrlBuilder imageUrlBuilder;
 
     public ProfileAvatarController(
             final UserQueryService userQueryService,
+            @Qualifier("profileAvatarUrlBuilder") final ImageUrlBuilder imageUrlBuilder,
             @Qualifier("profileAvatarService") final ImageService imageService,
-            final ImageMapper imageMapper,
-            final ImageUrlBuilder imageUrlBuilder
+            final ImageMapper imageMapper
     ) {
         this.userQueryService = userQueryService;
+        this.imageUrlBuilder = imageUrlBuilder;
         this.imageService = imageService;
         this.imageMapper = imageMapper;
-        this.imageUrlBuilder = imageUrlBuilder;
     }
 
     @PostMapping

--- a/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
@@ -49,12 +49,16 @@ public class ProfileAvatarController {
     }
 
     @GetMapping
-    public ImageResponse getProfileAvatar(@PathVariable Long userId) {
+    public ResponseEntity<?> getProfileAvatar(@PathVariable Long userId) {
         var profileAvatar = userQueryService.getUser(userId).getProfileAvatar();
+
+        if (profileAvatar == null) {
+            return ResponseEntity.noContent().build();
+        }
 
         var url = imageUrlBuilder.buildUrl(profileAvatar);
 
-        return new ImageResponse(profileAvatar, url);
+        return ResponseEntity.ok(new ImageResponse(profileAvatar, url));
     }
 
     @DeleteMapping("/{fileName}")

--- a/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarController.java
@@ -50,11 +50,13 @@ public class ProfileAvatarController {
 
     @GetMapping
     public ResponseEntity<?> getProfileAvatar(@PathVariable Long userId) {
-        var profileAvatar = userQueryService.getUser(userId).getProfileAvatar();
+        var user = userQueryService.getUser(userId);
 
-        if (profileAvatar == null) {
+        if (!user.hasProfileAvatar()) {
             return ResponseEntity.noContent().build();
         }
+
+        var profileAvatar = user.getProfileAvatar();
 
         var url = imageUrlBuilder.buildUrl(profileAvatar);
 

--- a/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarUrlBuilder.java
+++ b/src/main/java/com/github/jbence1994/webshop/image/ProfileAvatarUrlBuilder.java
@@ -1,0 +1,20 @@
+package com.github.jbence1994.webshop.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileAvatarUrlBuilder implements ImageUrlBuilder {
+    private final ProfileAvatarUploadDirectoryConfig profileAvatarUploadDirectoryConfig;
+
+    @Override
+    public String buildUrl(String fileName) {
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path(profileAvatarUploadDirectoryConfig.path() + "/")
+                .path(fileName)
+                .toUriString();
+    }
+}

--- a/src/main/java/com/github/jbence1994/webshop/product/ProductController.java
+++ b/src/main/java/com/github/jbence1994/webshop/product/ProductController.java
@@ -2,7 +2,7 @@ package com.github.jbence1994.webshop.product;
 
 import com.github.jbence1994.webshop.image.ImageUrlBuilder;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,13 +17,26 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/products")
-@RequiredArgsConstructor
 public class ProductController {
-    private final ProductQueryService productQueryService;
     private final CategoryQueryService categoryQueryService;
+    private final ProductQueryService productQueryService;
+    private final ImageUrlBuilder imageUrlBuilder;
     private final ProductService productService;
     private final ProductMapper productMapper;
-    private final ImageUrlBuilder imageUrlBuilder;
+
+    public ProductController(
+            final CategoryQueryService categoryQueryService,
+            final ProductQueryService productQueryService,
+            @Qualifier("productPhotoUrlBuilder") final ImageUrlBuilder imageUrlBuilder,
+            final ProductService productService,
+            final ProductMapper productMapper
+    ) {
+        this.categoryQueryService = categoryQueryService;
+        this.productQueryService = productQueryService;
+        this.imageUrlBuilder = imageUrlBuilder;
+        this.productService = productService;
+        this.productMapper = productMapper;
+    }
 
     @GetMapping
     public List<ProductDto> getProducts(

--- a/src/test/java/com/github/jbence1994/webshop/image/ProductPhotoControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/image/ProductPhotoControllerTests.java
@@ -31,13 +31,13 @@ public class ProductPhotoControllerTests {
     private ProductPhotoQueryService productPhotoQueryService;
 
     @Mock
+    private ImageUrlBuilder imageUrlBuilder;
+
+    @Mock
     private ImageService imageService;
 
     @Mock
     private ImageMapper imageMapper;
-
-    @Mock
-    private ImageUrlBuilder imageUrlBuilder;
 
     @InjectMocks
     private ProductPhotoController productPhotoController;

--- a/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarControllerTests.java
@@ -31,13 +31,13 @@ public class ProfileAvatarControllerTests {
     private UserQueryService userQueryService;
 
     @Mock
+    private ImageUrlBuilder imageUrlBuilder;
+
+    @Mock
     private ImageService imageService;
 
     @Mock
     private ImageMapper imageMapper;
-
-    @Mock
-    private ImageUrlBuilder imageUrlBuilder;
 
     @InjectMocks
     private ProfileAvatarController profileAvatarController;

--- a/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/image/ProfileAvatarControllerTests.java
@@ -13,6 +13,7 @@ import static com.github.jbence1994.webshop.image.ImageTestConstants.PHOTO_FILE_
 import static com.github.jbence1994.webshop.image.ImageTestConstants.PHOTO_URL;
 import static com.github.jbence1994.webshop.image.ImageUploadTestObject.jpegImageUpload;
 import static com.github.jbence1994.webshop.image.MultipartFileTestObject.multipartFile;
+import static com.github.jbence1994.webshop.user.UserTestObject.user;
 import static com.github.jbence1994.webshop.user.UserTestObject.userWithAvatar;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -57,13 +58,24 @@ public class ProfileAvatarControllerTests {
     }
 
     @Test
-    public void getProfileAvatarTest() {
+    public void getProfileAvatarTest_HappyPath_ProfileHaveAvatar() {
         when(userQueryService.getUser(anyLong())).thenReturn(userWithAvatar());
         when(imageUrlBuilder.buildUrl(any())).thenReturn(AVATAR_URL);
 
         var result = profileAvatarController.getProfileAvatar(1L);
 
-        assertThat(result, not(nullValue()));
+        assertThat(result.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(result.getBody(), not(nullValue()));
+    }
+
+    @Test
+    public void getProfileAvatarTest_UnhappyPath_ProfileDontHaveAvatar() {
+        when(userQueryService.getUser(anyLong())).thenReturn(user());
+
+        var result = profileAvatarController.getProfileAvatar(1L);
+
+        assertThat(result.getStatusCode(), equalTo(HttpStatus.NO_CONTENT));
+        assertThat(result.getBody(), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/com/github/jbence1994/webshop/product/ProductControllerTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/product/ProductControllerTests.java
@@ -34,10 +34,10 @@ import static org.mockito.Mockito.when;
 class ProductControllerTests {
 
     @Mock
-    private ProductQueryService productQueryService;
+    private CategoryQueryService categoryQueryService;
 
     @Mock
-    private CategoryQueryService categoryQueryService;
+    private ProductQueryService productQueryService;
 
     @Mock
     private ProductService productService;


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Bugfixing Profile Avatar url building by adding a separate URL builder component which returns `avatars/profiles` in the content path, not `photos/products` as before did by the only URL builder.