### PR TITLE
Storing `originalCartTotal`, `cartTotal`, `discountAmount` and `shippingCost` fields in `CheckoutSession`

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
@@ -39,9 +39,7 @@ public class CheckoutServiceImpl implements CheckoutService {
             throw new EmptyCartException(cartId);
         }
 
-        var checkoutSession = new CheckoutSession();
-        checkoutSession.setCart(cart);
-        checkoutSession.setStatus(CheckoutStatus.PENDING);
+        var checkoutSession = CheckoutSession.from(cart, shippingConfig.shippingCost());
 
         checkoutRepository.save(checkoutSession);
 

--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSession.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSession.java
@@ -59,6 +59,21 @@ public class CheckoutSession {
     @GeneratedColumn("created_at")
     private LocalDateTime createdAt;
 
+    public static CheckoutSession from(Cart cart, BigDecimal shippingCost) {
+        var cartTotal = cart.calculateTotal();
+
+        var checkoutSession = new CheckoutSession();
+
+        checkoutSession.setCart(cart);
+        checkoutSession.setOriginalCartTotal(cartTotal);
+        checkoutSession.setCartTotal(cartTotal);
+        checkoutSession.setDiscountAmount(BigDecimal.ZERO);
+        checkoutSession.setShippingCost(shippingCost);
+        checkoutSession.setStatus(CheckoutStatus.PENDING);
+
+        return checkoutSession;
+    }
+
     public boolean hasCouponApplied() {
         return appliedCoupon != null;
     }

--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSession.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSession.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GeneratedColumn;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -29,7 +30,6 @@ import java.util.UUID;
 @Setter
 public class CheckoutSession {
 
-    // TODO: CheckoutPrice shall be persisted later.
     // TODO: expiration shall be persisted later.
 
     @Id
@@ -39,6 +39,14 @@ public class CheckoutSession {
     @ManyToOne
     @JoinColumn(name = "cart_id")
     private Cart cart;
+
+    private BigDecimal originalCartTotal;
+
+    private BigDecimal cartTotal;
+
+    private BigDecimal discountAmount;
+
+    private BigDecimal shippingCost;
 
     @ManyToOne
     @JoinColumn(name = "applied_coupon")

--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSessionDto.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutSessionDto.java
@@ -1,11 +1,15 @@
 package com.github.jbence1994.webshop.checkout;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record CheckoutSessionDto(
         UUID id,
         UUID cartId,
+        BigDecimal cartTotal,
+        BigDecimal discountAmount,
+        BigDecimal shippingCost,
         String appliedCoupon,
         String status,
         LocalDateTime createdAt

--- a/src/main/resources/db/migration/V1__database_schema.sql
+++ b/src/main/resources/db/migration/V1__database_schema.sql
@@ -183,11 +183,15 @@ CREATE TABLE IF NOT EXISTS cart_items
 
 CREATE TABLE IF NOT EXISTS checkout_sessions
 (
-    id             BINARY(16)  NOT NULL PRIMARY KEY DEFAULT (UUID_TO_BIN(UUID())),
-    cart_id        BINARY(16)  NOT NULL,
-    applied_coupon VARCHAR(25),
-    status         VARCHAR(20) NOT NULL             DEFAULT 'PENDING',
-    created_at     DATETIME    NOT NULL             DEFAULT CURRENT_TIMESTAMP,
+    id                  BINARY(16)     NOT NULL PRIMARY KEY DEFAULT (UUID_TO_BIN(UUID())),
+    cart_id             BINARY(16)     NOT NULL,
+    original_cart_total DECIMAL(10, 2) NOT NULL,
+    cart_total          DECIMAL(10, 2) NOT NULL,
+    discount_amount     DECIMAL(10, 2) NOT NULL,
+    shipping_cost       DECIMAL(10, 2) NOT NULL,
+    applied_coupon      VARCHAR(25),
+    status              VARCHAR(20)    NOT NULL             DEFAULT 'PENDING',
+    created_at          DATETIME       NOT NULL             DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_checkout_sessions_carts
         FOREIGN KEY (cart_id) REFERENCES carts (id)
             ON DELETE NO ACTION

--- a/src/test/java/com/github/jbence1994/webshop/cart/CartItemDtoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/cart/CartItemDtoTestObject.java
@@ -3,15 +3,10 @@ package com.github.jbence1994.webshop.cart;
 import java.math.BigDecimal;
 
 import static com.github.jbence1994.webshop.cart.CartProductDtoTestObject.cartProductDto1;
-import static com.github.jbence1994.webshop.cart.CartProductDtoTestObject.cartProductDto2;
 
 public final class CartItemDtoTestObject {
     public static CartItemDto cartItemDto1() {
         return buildCartItemDto(cartProductDto1(), 1, BigDecimal.valueOf(49.99));
-    }
-
-    public static CartItemDto cartItemDto2() {
-        return buildCartItemDto(cartProductDto2(), 1, BigDecimal.valueOf(89.99));
     }
 
     public static CartItemDto updatedCartItemDto() {

--- a/src/test/java/com/github/jbence1994/webshop/cart/CartProductDtoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/cart/CartProductDtoTestObject.java
@@ -3,7 +3,6 @@ package com.github.jbence1994.webshop.cart;
 import java.math.BigDecimal;
 
 import static com.github.jbence1994.webshop.product.ProductTestConstants.PRODUCT_1_NAME;
-import static com.github.jbence1994.webshop.product.ProductTestConstants.PRODUCT_2_NAME;
 
 public final class CartProductDtoTestObject {
     public static CartProductDto cartProductDto1() {
@@ -11,14 +10,6 @@ public final class CartProductDtoTestObject {
                 1L,
                 PRODUCT_1_NAME,
                 BigDecimal.valueOf(49.99)
-        );
-    }
-
-    public static CartProductDto cartProductDto2() {
-        return new CartProductDto(
-                2L,
-                PRODUCT_2_NAME,
-                BigDecimal.valueOf(89.99)
         );
     }
 }

--- a/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionDtoTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionDtoTestObject.java
@@ -1,8 +1,11 @@
 package com.github.jbence1994.webshop.checkout;
 
+import java.math.BigDecimal;
+
 import static com.github.jbence1994.webshop.cart.CartTestConstants.CART_ID;
 import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.CHECKOUT_SESSION_ID;
 import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.CREATED_AT;
+import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.SHIPPING_COST;
 import static com.github.jbence1994.webshop.coupon.CouponTestConstants.COUPON_1_CODE;
 
 public final class CheckoutSessionDtoTestObject {
@@ -18,6 +21,9 @@ public final class CheckoutSessionDtoTestObject {
         return new CheckoutSessionDto(
                 CHECKOUT_SESSION_ID,
                 CART_ID,
+                BigDecimal.valueOf(49.99),
+                BigDecimal.valueOf(49.99),
+                SHIPPING_COST,
                 appliedCoupon,
                 CheckoutStatus.PENDING.name(),
                 CREATED_AT

--- a/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionTestObject.java
+++ b/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionTestObject.java
@@ -3,38 +3,87 @@ package com.github.jbence1994.webshop.checkout;
 import com.github.jbence1994.webshop.cart.Cart;
 import com.github.jbence1994.webshop.coupon.Coupon;
 
+import java.math.BigDecimal;
+
 import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithFiveItems;
 import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithOneItem;
 import static com.github.jbence1994.webshop.cart.CartTestObject.emptyCart;
 import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.CHECKOUT_SESSION_ID;
 import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.CREATED_AT;
+import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.SHIPPING_COST;
 import static com.github.jbence1994.webshop.coupon.CouponTestObject.percentOffNotExpiredCoupon;
 
 public final class CheckoutSessionTestObject {
     public static CheckoutSession checkoutSession1() {
-        return buildCheckoutSession(cartWithOneItem(), null, CheckoutStatus.PENDING);
+        return buildCheckoutSession(
+                cartWithOneItem(),
+                BigDecimal.valueOf(49.99),
+                BigDecimal.valueOf(49.99),
+                BigDecimal.ZERO,
+                null,
+                CheckoutStatus.PENDING
+        );
     }
 
     public static CheckoutSession checkoutSession2() {
-        return buildCheckoutSession(cartWithFiveItems(), null, CheckoutStatus.PENDING);
+        return buildCheckoutSession(
+                cartWithFiveItems(),
+                BigDecimal.valueOf(249.95),
+                BigDecimal.valueOf(249.95),
+                BigDecimal.ZERO,
+                null,
+                CheckoutStatus.PENDING
+        );
     }
 
     public static CheckoutSession checkoutSessionWithPercentOffTypeOfAppliedCoupon() {
-        return buildCheckoutSession(cartWithOneItem(), percentOffNotExpiredCoupon(), CheckoutStatus.PENDING);
+        return buildCheckoutSession(
+                cartWithOneItem(),
+                BigDecimal.valueOf(49.99),
+                BigDecimal.valueOf(5.00),
+                BigDecimal.valueOf(44.99),
+                percentOffNotExpiredCoupon(),
+                CheckoutStatus.PENDING
+        );
     }
 
     public static CheckoutSession checkoutSessionWithEmptyCart() {
-        return buildCheckoutSession(emptyCart(), null, CheckoutStatus.PENDING);
+        return buildCheckoutSession(
+                emptyCart(),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                null,
+                CheckoutStatus.PENDING
+        );
     }
 
     public static CheckoutSession completedCheckoutSession() {
-        return buildCheckoutSession(cartWithOneItem(), null, CheckoutStatus.COMPLETED);
+        return buildCheckoutSession(
+                cartWithOneItem(),
+                BigDecimal.valueOf(49.99),
+                BigDecimal.valueOf(49.99),
+                BigDecimal.ZERO,
+                null,
+                CheckoutStatus.COMPLETED
+        );
     }
 
-    private static CheckoutSession buildCheckoutSession(Cart cart, Coupon appliedCoupon, CheckoutStatus status) {
+    private static CheckoutSession buildCheckoutSession(
+            Cart cart,
+            BigDecimal originalCartTotal,
+            BigDecimal cartTotal,
+            BigDecimal discountAmount,
+            Coupon appliedCoupon,
+            CheckoutStatus status
+    ) {
         return new CheckoutSession(
                 CHECKOUT_SESSION_ID,
                 cart,
+                originalCartTotal,
+                cartTotal,
+                discountAmount,
+                SHIPPING_COST,
                 appliedCoupon,
                 status,
                 CREATED_AT

--- a/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutSessionTests.java
@@ -7,12 +7,19 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static com.github.jbence1994.webshop.cart.CartTestObject.cartWithOneItem;
 import static com.github.jbence1994.webshop.checkout.CheckoutSessionTestObject.checkoutSession1;
 import static com.github.jbence1994.webshop.checkout.CheckoutSessionTestObject.checkoutSessionWithPercentOffTypeOfAppliedCoupon;
+import static com.github.jbence1994.webshop.checkout.CheckoutTestConstants.SHIPPING_COST;
 import static com.github.jbence1994.webshop.coupon.CouponTestConstants.COUPON_1_CODE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class CheckoutSessionTests {
 
@@ -21,6 +28,20 @@ public class CheckoutSessionTests {
                 Arguments.of("Checkout session has coupon applied", checkoutSessionWithPercentOffTypeOfAppliedCoupon(), true),
                 Arguments.of("Checkout session does not have a coupon applied", checkoutSession1(), false)
         );
+    }
+
+    @Test
+    public void fromTest() {
+        var result = CheckoutSession.from(cartWithOneItem(), SHIPPING_COST);
+
+        assertThat(result, not(nullValue()));
+        assertThat(result, allOf(
+                hasProperty("originalCartTotal", comparesEqualTo(checkoutSession1().getOriginalCartTotal())),
+                hasProperty("cartTotal", comparesEqualTo(checkoutSession1().getCartTotal())),
+                hasProperty("discountAmount", comparesEqualTo(checkoutSession1().getDiscountAmount())),
+                hasProperty("shippingCost", comparesEqualTo(checkoutSession1().getShippingCost())),
+                hasProperty("status", equalTo(CheckoutStatus.PENDING))
+        ));
     }
 
     @ParameterizedTest(name = "{index} => {0}")


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Storing `originalCartTotal`, `cartTotal`, `discountAmount` and `shippingCost` fields in `CheckoutSession`.