### PR TITLE
Including `userId` parameter in `isCouponRedeemed` SQL query to handle same coupon used by multiple users

### DIFF
--- a/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImpl.java
@@ -57,7 +57,7 @@ public class CheckoutServiceImpl implements CheckoutService {
             throw new ExpiredCouponException(couponCode);
         }
 
-        if (couponQueryService.isRedeemedCoupon(couponCode)) {
+        if (couponQueryService.isCouponRedeemed(couponCode)) {
             throw new CouponAlreadyRedeemedException(couponCode);
         }
 

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryService.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryService.java
@@ -7,5 +7,5 @@ public interface CouponQueryService {
 
     Coupon getCoupon(String code);
 
-    boolean isRedeemedCoupon(String code);
+    boolean isCouponRedeemed(String code);
 }

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImpl.java
@@ -30,6 +30,8 @@ public class CouponQueryServiceImpl implements CouponQueryService {
 
     @Override
     public boolean isCouponRedeemed(String code) {
-        return couponRepository.isCouponRedeemed(code) == 1;
+        var user = authService.getCurrentUser();
+
+        return couponRepository.isCouponRedeemed(user.getId(), code) == 1;
     }
 }

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImpl.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class CouponQueryServiceImpl implements CouponQueryService {
     }
 
     @Override
-    public boolean isRedeemedCoupon(String code) {
-        return couponRepository.isRedeemedCoupon(code) == 1;
+    public boolean isCouponRedeemed(String code) {
+        return couponRepository.isCouponRedeemed(code) == 1;
     }
 }

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
@@ -19,7 +19,7 @@ public interface CouponRepository extends JpaRepository<Coupon, String> {
             value = "SELECT EXISTS (SELECT * FROM user_coupons WHERE coupon_code = :couponCode AND redeemed = 1);",
             nativeQuery = true
     )
-    int isRedeemedCoupon(@Param("couponCode") String couponCode);
+    int isCouponRedeemed(@Param("couponCode") String couponCode);
 
     @Modifying
     @Query(

--- a/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
+++ b/src/main/java/com/github/jbence1994/webshop/coupon/CouponRepository.java
@@ -16,10 +16,10 @@ public interface CouponRepository extends JpaRepository<Coupon, String> {
     Optional<Coupon> findByCouponCodeAndUserId(@Param("couponCode") String couponCode, @Param("userId") Long userId);
 
     @Query(
-            value = "SELECT EXISTS (SELECT * FROM user_coupons WHERE coupon_code = :couponCode AND redeemed = 1);",
+            value = "SELECT EXISTS (SELECT * FROM user_coupons WHERE user_id = :userId AND coupon_code = :couponCode AND redeemed = 1);",
             nativeQuery = true
     )
-    int isCouponRedeemed(@Param("couponCode") String couponCode);
+    int isCouponRedeemed(@Param("userId") Long userId, @Param("couponCode") String couponCode);
 
     @Modifying
     @Query(

--- a/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/checkout/CheckoutServiceImplTests.java
@@ -121,14 +121,14 @@ public class CheckoutServiceImplTests {
     public void applyCouponToCheckoutSessionTest_HappyPath() {
         when(checkoutQueryService.getCheckoutSession(any())).thenReturn(checkoutSession1());
         when(couponQueryService.getCoupon(any())).thenReturn(percentOffNotExpiredCoupon());
-        when(couponQueryService.isRedeemedCoupon(any())).thenReturn(false);
+        when(couponQueryService.isCouponRedeemed(any())).thenReturn(false);
         when(checkoutRepository.save(any())).thenReturn(checkoutSessionWithPercentOffTypeOfAppliedCoupon());
 
         assertDoesNotThrow(() -> checkoutService.applyCouponToCheckoutSession(CART_ID, COUPON_1_CODE));
 
         verify(checkoutQueryService, times(1)).getCheckoutSession(any());
         verify(couponQueryService, times(1)).getCoupon(any());
-        verify(couponQueryService, times(1)).isRedeemedCoupon(any());
+        verify(couponQueryService, times(1)).isCouponRedeemed(any());
         verify(checkoutRepository, times(1)).save(any());
     }
 
@@ -146,7 +146,7 @@ public class CheckoutServiceImplTests {
 
         verify(checkoutQueryService, times(1)).getCheckoutSession(any());
         verify(couponQueryService, times(1)).getCoupon(any());
-        verify(couponQueryService, never()).isRedeemedCoupon(any());
+        verify(couponQueryService, never()).isCouponRedeemed(any());
         verify(checkoutRepository, never()).save(any());
     }
 
@@ -154,7 +154,7 @@ public class CheckoutServiceImplTests {
     public void applyCouponToCheckoutSessionTest_UnhappyPath_CouponAlreadyRedeemedException() {
         when(checkoutQueryService.getCheckoutSession(any())).thenReturn(checkoutSession1());
         when(couponQueryService.getCoupon(any())).thenReturn(percentOffNotExpiredCoupon());
-        when(couponQueryService.isRedeemedCoupon(any())).thenReturn(true);
+        when(couponQueryService.isCouponRedeemed(any())).thenReturn(true);
 
         var result = assertThrows(
                 CouponAlreadyRedeemedException.class,
@@ -165,7 +165,7 @@ public class CheckoutServiceImplTests {
 
         verify(checkoutQueryService, times(1)).getCheckoutSession(any());
         verify(couponQueryService, times(1)).getCoupon(any());
-        verify(couponQueryService, times(1)).isRedeemedCoupon(any());
+        verify(couponQueryService, times(1)).isCouponRedeemed(any());
         verify(checkoutRepository, never()).save(any());
     }
 

--- a/src/test/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImplTests.java
+++ b/src/test/java/com/github/jbence1994/webshop/coupon/CouponQueryServiceImplTests.java
@@ -43,7 +43,7 @@ public class CouponQueryServiceImplTests {
     @InjectMocks
     private CouponQueryServiceImpl couponQueryService;
 
-    private static Stream<Arguments> isRedeemedCouponTestParams() {
+    private static Stream<Arguments> isCouponRedeemedTestParams() {
         return Stream.of(
                 Arguments.of("Coupon is redeemed", COUPON_1_CODE, 1, true),
                 Arguments.of("Coupon is not yet redeemed", COUPON_2_CODE, 0, false)
@@ -93,16 +93,16 @@ public class CouponQueryServiceImplTests {
     }
 
     @ParameterizedTest(name = "{index} => {0}")
-    @MethodSource("isRedeemedCouponTestParams")
-    public void isRedeemedCouponTests(
+    @MethodSource("isCouponRedeemedTestParams")
+    public void isCouponRedeemedTests(
             String testCase,
             String couponCode,
             int returnValueFromRepository,
             boolean expectedResult
     ) {
-        when(couponRepository.isRedeemedCoupon(any())).thenReturn(returnValueFromRepository);
+        when(couponRepository.isCouponRedeemed(any())).thenReturn(returnValueFromRepository);
 
-        var result = couponQueryService.isRedeemedCoupon(couponCode);
+        var result = couponQueryService.isCouponRedeemed(couponCode);
 
         assertThat(result, equalTo(expectedResult));
     }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Including `userId` parameter in `isCouponRedeemed` SQL query to handle same coupon used by multiple users.